### PR TITLE
Improve signup workflow and token persistence

### DIFF
--- a/backend/src/main/java/com/example/backend/controllers/UsuarioController.java
+++ b/backend/src/main/java/com/example/backend/controllers/UsuarioController.java
@@ -54,6 +54,15 @@ public class UsuarioController {
     @PostMapping("/add")
     public ResponseEntity<String> addData(@RequestBody Map<String, Object> data) {
         try {
+            String email = (String) data.get("email");
+            if (email != null) {
+                ApiFuture<QuerySnapshot> future = db.collection("usuarios")
+                        .whereEqualTo("email", email).limit(1).get();
+                if (!future.get().isEmpty()) {
+                    return ResponseEntity.status(HttpStatus.CONFLICT)
+                            .body("Email já cadastrado.");
+                }
+            }
             if (data.containsKey("senha")) {
                 String senhaPlana = (String) data.get("senha");
                 String senhaHash = BCrypt.hashpw(senhaPlana, BCrypt.gensalt());

--- a/frontend/components/SignUpForm/index.tsx
+++ b/frontend/components/SignUpForm/index.tsx
@@ -14,11 +14,25 @@ import { Container } from "./styles";
 export const SignUpForm = () => {
   const [form, setForm] = useState({ username: "", email: "", password: "", confirmPassword: "" });
   const [loading, setLoading] = useState(false);
-  const { updateSessionId } = useContext(PageContext);
+  const [strength, setStrength] = useState(0);
+  const { updateSessionId, handleLogin } = useContext(PageContext);
   const [user] = useAuthState(auth);
+
+  const calcStrength = (password: string) => {
+    let score = 0;
+    if (password.length >= 8) score++;
+    if (/[A-Z]/.test(password)) score++;
+    if (/[a-z]/.test(password)) score++;
+    if (/[0-9]/.test(password)) score++;
+    if (/[^A-Za-z0-9]/.test(password)) score++;
+    return score;
+  };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
+    if (e.target.name === 'password') {
+      setStrength(calcStrength(e.target.value));
+    }
   };
 
   const handleSubmit = async (e: FormEvent) => {
@@ -38,7 +52,7 @@ export const SignUpForm = () => {
       });
       const text = await response.text();
       if (!response.ok) throw new Error(text);
-      updateSessionId?.(text);
+      await handleLogin(form.email, form.password);
     } catch (error) {
       console.error("Erro ao criar usuário:", error);
     } finally {
@@ -90,6 +104,12 @@ export const SignUpForm = () => {
               onChange={handleChange}
               className="w-full h-12 pl-8 border-b-2 input"
             />
+            <div className="w-full h-2 bg-gray-300 rounded mt-1">
+              <div
+                className={`${strength <= 2 ? 'bg-red-500' : strength === 3 ? 'bg-yellow-500' : 'bg-green-500'} h-full rounded`}
+                style={{ width: `${(strength / 5) * 100}%` }}
+              />
+            </div>
 
             <label className="block mt-6" htmlFor="confirmPassword">Confirme a senha</label>
             <input

--- a/frontend/components/SingButtons/index.jsx
+++ b/frontend/components/SingButtons/index.jsx
@@ -3,7 +3,7 @@ import { Container } from './styles';
 import Link from "next/link";
 import Image from "next/image";
 import { useContext, useState } from "react";
-// import { auth } from '@/firebase';
+import { auth } from '@/lib/firebase';
 import { signOut as firebaseSignOut } from 'firebase/auth';
 import { PageContext } from '@/context/PageContext';
 import defaultIcon from "@/assets/img/default_user_photo.png";
@@ -12,7 +12,7 @@ import { useRouter } from 'next/navigation';
 
 export const SignButtons = () => {
   const [toggleDropdown, setToggleDropdown] = useState(false);
-  const { updateSessionId, userId, user } = useContext(PageContext);
+  const { updateSessionId, updateToken, updateUser, userId, user } = useContext(PageContext);
   const router = useRouter();
 
 
@@ -20,6 +20,12 @@ export const SignButtons = () => {
     firebaseSignOut(auth);
     if (typeof updateSessionId === 'function') {
       updateSessionId("");
+    }
+    if (typeof updateToken === 'function') {
+      updateToken("");
+    }
+    if (typeof updateUser === 'function') {
+      updateUser(null);
     }
   }
 

--- a/frontend/context/PageContext.tsx
+++ b/frontend/context/PageContext.tsx
@@ -15,7 +15,7 @@ type PageContextProps = {
   handleLogin: (email: string, password: string) => Promise<void>;
   handleSignUp: (name: string, email: string, password: string) => Promise<void>;
   updateSessionId?: (id: string) => void;
-  updateUser?: (user: User) => void;
+  updateUser?: (user: User | null) => void;
   updateToken?: (token: string) => void;
 };
 
@@ -96,7 +96,7 @@ export const PageProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const updateSessionId = (id: string) => setSessionId(id);
-  const updateUser = (u: User) => setUser(u);
+  const updateUser = (u: User | null) => setUser(u);
   const updateToken = (t: string) => setToken(t);
 
   const contextValue = useMemo(() => ({

--- a/frontend/context/PageContext.tsx
+++ b/frontend/context/PageContext.tsx
@@ -34,6 +34,32 @@ export const PageProvider = ({ children }: { children: ReactNode }) => {
   const [sessionId, setSessionId] = useState<string>("");
   const [token, setToken] = useState<string>("");
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const storedToken = localStorage.getItem('token');
+    const storedSession = localStorage.getItem('sessionId');
+    if (storedToken) setToken(storedToken);
+    if (storedSession) setSessionId(storedSession);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (token) {
+      localStorage.setItem('token', token);
+    } else {
+      localStorage.removeItem('token');
+    }
+  }, [token]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (sessionId) {
+      localStorage.setItem('sessionId', sessionId);
+    } else {
+      localStorage.removeItem('sessionId');
+    }
+  }, [sessionId]);
+
   const handleLogin = async (email: string, password: string) => {
     try {
       const res = await fetch("/api/login", {


### PR DESCRIPTION
## Summary
- prevent duplicate email registration on backend
- persist user token and session info across refreshes
- show password strength meter in sign up form
- auto login new users on successful sign up

## Testing
- `npm run lint` *(fails: next not found)*
- `./mvnw -q test` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_686041d80f9c83289b6eaf9f345a6fbd