### PR TITLE
Add allPets listing page

### DIFF
--- a/frontend/app/allPets/page.tsx
+++ b/frontend/app/allPets/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Section } from "@/components/Section";
+import { LoadingSection } from "@/components/LoadingSection";
+import { PetCard } from "@/components/PetCard";
+import { fetchTk } from "@/lib/helper";
+
+interface Pet {
+  id: string;
+  nome: string;
+  descricao?: string;
+  tipo?: string;
+  tags?: string[];
+  imagem?: string;
+}
+
+export default function AllPetsPage() {
+  const [pets, setPets] = useState<Pet[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchTk("/api/pets")
+      .then((res) => res.json())
+      .then((data) => setPets(data))
+      .catch((err) => console.error("fetch pets", err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <Section type="flex-list">
+      {loading ? (
+        <LoadingSection />
+      ) : (
+        pets.map((pet) => <PetCard key={pet.id} pet={pet} />)
+      )}
+    </Section>
+  );
+}

--- a/frontend/components/PetCard/index.tsx
+++ b/frontend/components/PetCard/index.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { SafeImage } from "../SafeImage";
+import * as Styled from "./styles";
+
+export interface PetCardProps {
+  pet: {
+    id: string;
+    nome: string;
+    descricao?: string;
+    tipo?: string;
+    tags?: string[];
+    imagem?: string;
+  };
+}
+
+export const PetCard = ({ pet }: PetCardProps) => {
+  return (
+    <Styled.Container>
+      <Styled.ImageWrapper>
+        <SafeImage src={pet.imagem ?? "https://via.placeholder.com/300x200"} text={pet.nome} height={200} />
+      </Styled.ImageWrapper>
+      <Styled.Content>
+        <h3>{pet.nome}</h3>
+        {pet.tipo && <span className="tipo">{pet.tipo}</span>}
+        {pet.descricao && <p className="descricao">{pet.descricao}</p>}
+        {pet.tags && pet.tags.length > 0 && (
+          <Styled.Tags>
+            {pet.tags.map((tag) => (
+              <span key={tag} className="tag">{tag}</span>
+            ))}
+          </Styled.Tags>
+        )}
+      </Styled.Content>
+    </Styled.Container>
+  );
+};

--- a/frontend/components/PetCard/styles.ts
+++ b/frontend/components/PetCard/styles.ts
@@ -1,0 +1,60 @@
+import styled, { DefaultTheme, css } from 'styled-components';
+
+export const Container = styled.div`
+  ${({ theme }: { theme: DefaultTheme }) => css`
+    background: ${theme.colors.secondaryBg};
+    color: ${theme.colors.mainColor};
+    border-radius: ${theme.radius.default};
+    overflow: hidden;
+    width: 300px;
+    box-shadow: ${theme.shadow.greyInsetShadow};
+    display: flex;
+    flex-direction: column;
+  `}
+`;
+
+export const ImageWrapper = styled.div`
+  ${({ theme }: { theme: DefaultTheme }) => css`
+    width: 100%;
+    height: 200px;
+    background: ${theme.colors.lightGrey};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  `}
+`;
+
+export const Content = styled.div`
+  ${({ theme }: { theme: DefaultTheme }) => css`
+    padding: ${theme.spacings.small};
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacings.xsmall};
+
+    & h3 {
+      margin: 0;
+    }
+
+    & .tipo {
+      font-size: 1.4rem;
+      color: ${theme.colors.lightBlue};
+    }
+
+    & .descricao {
+      font-size: 1.4rem;
+    }
+
+    & .tag {
+      background: ${theme.colors.darkGrey};
+      padding: 2px 6px;
+      border-radius: ${theme.radius.small};
+      font-size: 1.2rem;
+    }
+  `}
+`;
+
+export const Tags = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+`;


### PR DESCRIPTION
## Summary
- create PetCard component for pet display
- add AllPets page to list pets from backend

## Testing
- `npm run lint` *(fails: next not found)*
- `./mvnw -q test` *(fails: could not fetch maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68606b909b488328a69a66874b94633d