### PR TITLE
Fix Google login token creation

### DIFF
--- a/backend/src/main/java/com/example/backend/controllers/UsuarioController.java
+++ b/backend/src/main/java/com/example/backend/controllers/UsuarioController.java
@@ -145,6 +145,8 @@ public class UsuarioController {
             data = new HashMap<>();
         }
         data.put("id", doc.getId());
+        String token = tokenService.createSession(doc.getId());
+        data.put("token", token);
         return ResponseEntity.ok(data);
     }
 
@@ -162,6 +164,8 @@ public class UsuarioController {
                 existingData = new HashMap<>();
             }
             existingData.put("id", doc.getId());
+            String token = tokenService.createSession(doc.getId());
+            existingData.put("token", token);
             return ResponseEntity.ok(existingData);
         }
 
@@ -172,6 +176,8 @@ public class UsuarioController {
         DocumentReference newDoc = db.collection("usuarios").document();
         newDoc.set(userData);
         userData.put("id", newDoc.getId());
+        String token = tokenService.createSession(newDoc.getId());
+        userData.put("token", token);
         return ResponseEntity.status(HttpStatus.CREATED).body(userData);
     }
 }

--- a/frontend/components/LoginForm/index.tsx
+++ b/frontend/components/LoginForm/index.tsx
@@ -15,7 +15,7 @@ export const LoginForm = () => {
   const router = useRouter();
   const [form, setForm] = useState({ email: '', password: '' });
   const [loading, setLoading] = useState(false);
-  const { handleLogin, updateSessionId, updateUser } = useContext(PageContext);
+  const { handleLogin, updateSessionId, updateToken, updateUser } = useContext(PageContext);
 
   useEffect(() => {
     const checkRedirect = async () => {
@@ -27,12 +27,13 @@ export const LoginForm = () => {
           userData: googleUser,
         });
         updateSessionId?.(response._id ?? response.id);
+        updateToken?.(response.token ?? '');
         updateUser?.(response);
         router.push('/');
       }
     };
     checkRedirect();
-  }, [router, updateSessionId, updateUser]);
+  }, [router, updateSessionId, updateToken, updateUser]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm(prev => ({ ...prev, [e.target.name]: e.target.value }));
@@ -61,6 +62,7 @@ export const LoginForm = () => {
       const response = await loginUserWithGoogle();
       if (response?.id) {
         updateSessionId?.(response._id ?? response.id);
+        updateToken?.(response.token ?? '');
         updateUser?.(response);
         router.push('/');
       }

--- a/frontend/components/SignUpForm/index.tsx
+++ b/frontend/components/SignUpForm/index.tsx
@@ -17,7 +17,7 @@ export const SignUpForm = () => {
   const [form, setForm] = useState({ username: "", email: "", password: "", confirmPassword: "" });
   const [loading, setLoading] = useState(false);
   const [strength, setStrength] = useState(0);
-  const { updateSessionId, handleLogin, updateUser } = useContext(PageContext);
+  const { updateSessionId, handleLogin, updateToken, updateUser } = useContext(PageContext);
   const [user] = useAuthState(auth);
   const router = useRouter();
 
@@ -31,6 +31,7 @@ export const SignUpForm = () => {
           userData: googleUser,
         });
         updateSessionId?.(response?._id ?? response?.id ?? '');
+        updateToken?.(response.token ?? '');
         if (typeof updateUser === 'function') {
           updateUser(response);
         }
@@ -38,7 +39,7 @@ export const SignUpForm = () => {
       }
     };
     checkRedirect();
-  }, [router, updateSessionId, updateUser]);
+  }, [router, updateSessionId, updateToken, updateUser]);
 
   const calcStrength = (password: string) => {
     let score = 0;
@@ -92,6 +93,7 @@ export const SignUpForm = () => {
         userData: googleUser,
       });
       updateSessionId?.(response?._id ?? response?.id ?? "");
+      updateToken?.(response.token ?? '');
       if (typeof updateUser === 'function') {
         updateUser(response);
       }


### PR DESCRIPTION
## Summary
- generate a session token when authenticating via Firebase
- store that token in the frontend after Google login

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/)*
- `npm run lint --silent` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68607dac51b48328a73252d005ebd2f6