### PR TITLE
Implement user pet management

### DIFF
--- a/backend/src/main/java/com/example/backend/services/PetService.java
+++ b/backend/src/main/java/com/example/backend/services/PetService.java
@@ -65,4 +65,8 @@ public class PetService {
         data.put("id", doc.getId());
         return data;
     }
+
+    public void updatePet(String id, Pet pet) throws Exception {
+        db.collection("pets").document(id).set(pet, com.google.cloud.firestore.SetOptions.merge());
+    }
 }

--- a/frontend/app/editPet/[id]/page.tsx
+++ b/frontend/app/editPet/[id]/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useContext, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { PageContext } from "@/context/PageContext";
+import { fetchTk } from "@/lib/helper";
+import EditPetForm from "@/components/EditPetForm/EditPetForm";
+
+interface Pet {
+  id: string;
+  nome: string;
+  descricao?: string;
+  tipo?: string;
+  tags?: string[];
+  imagem?: string;
+  localizacao?: Record<string, any>;
+}
+
+export default function EditPetPage({ params }: { params: { id: string } }) {
+  const { token } = useContext(PageContext);
+  const [pet, setPet] = useState<Pet | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!token) return;
+    fetchTk(`/api/pets/${params.id}`, { headers: { Authorization: token } })
+      .then((res) => res.json())
+      .then((data) => setPet(data))
+      .catch((err) => console.error("fetch pet", err));
+  }, [token, params.id]);
+
+  if (!pet) return <p>Carregando...</p>;
+
+  return (
+    <EditPetForm pet={pet} token={token!} onSuccess={() => router.push("/myPets")} />
+  );
+}

--- a/frontend/app/myPets/page.tsx
+++ b/frontend/app/myPets/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { useContext, useEffect, useState } from "react";
+import { PageContext } from "@/context/PageContext";
+import { fetchTk } from "@/lib/helper";
+import { Section } from "@/components/Section";
+import { LoadingSection } from "@/components/LoadingSection";
+import { PetCard } from "@/components/PetCard";
+import Link from "next/link";
+
+interface Pet {
+  id: string;
+  nome: string;
+  descricao?: string;
+  tipo?: string;
+  tags?: string[];
+  imagem?: string;
+}
+
+export default function MyPetsPage() {
+  const { token } = useContext(PageContext);
+  const [pets, setPets] = useState<Pet[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!token) return;
+    fetchTk("/api/pets/me", { headers: { Authorization: token } })
+      .then((res) => res.json())
+      .then((data) => setPets(data))
+      .catch((err) => console.error("fetch my pets", err))
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  return (
+    <Section type="flex-list">
+      {loading ? (
+        <LoadingSection />
+      ) : (
+        pets.map((pet) => (
+          <div key={pet.id}>
+            <PetCard pet={pet} />
+            <Link href={`/editPet/${pet.id}`}>Editar</Link>
+          </div>
+        ))
+      )}
+    </Section>
+  );
+}

--- a/frontend/app/myPets/page.tsx
+++ b/frontend/app/myPets/page.tsx
@@ -22,7 +22,11 @@ export default function MyPetsPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!token) return;
+    if (!token) {
+      console.error("No token found, redirecting to login");
+      window.location.href = "/login";
+      return;
+    };
     fetchTk("/api/pets/me", { headers: { Authorization: token } })
       .then((res) => res.json())
       .then((data) => setPets(data))

--- a/frontend/components/EditPetForm/EditPetForm.tsx
+++ b/frontend/components/EditPetForm/EditPetForm.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { ChangeEvent, FormEvent, useState } from "react";
+import { fetchTk } from "@/lib/helper";
+import { Container } from "./styles";
+import { TagChip } from "../TagChip";
+
+export interface EditPetFormProps {
+  pet: any;
+  token: string;
+  onSuccess?: () => void;
+}
+
+export default function EditPetForm({ pet, token, onSuccess }: EditPetFormProps) {
+  const [form, setForm] = useState<any>({
+    nome: pet.nome || "",
+    descricao: pet.descricao || "",
+    tipo: pet.tipo || "",
+    tags: pet.tags || [],
+    localizacao: {
+      pais: pet.localizacao?.pais || "",
+      estado: pet.localizacao?.estado || "",
+      cidade: pet.localizacao?.cidade || "",
+      bairro: pet.localizacao?.bairro || "",
+      rua: pet.localizacao?.rua || "",
+      numero: pet.localizacao?.numero || "",
+      cep: pet.localizacao?.cep || "",
+      latitude: pet.localizacao?.latitude || 0,
+      longitude: pet.localizacao?.longitude || 0,
+    },
+  });
+  const [tagInput, setTagInput] = useState("");
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    if (name.startsWith("localizacao.")) {
+      const key = name.split(".")[1];
+      setForm((prev: any) => ({
+        ...prev,
+        localizacao: { ...prev.localizacao, [key]: value },
+      }));
+    } else {
+      setForm((prev: any) => ({ ...prev, [name]: value }));
+    }
+  };
+
+  const handleTagInput = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    if (value.endsWith(",")) {
+      const tag = value.slice(0, -1).trim();
+      if (tag && !form.tags.includes(tag)) {
+        setForm((prev: any) => ({ ...prev, tags: [...prev.tags, tag] }));
+      }
+      setTagInput("");
+    } else {
+      setTagInput(value);
+    }
+  };
+
+  const removeTag = (tag: string) => {
+    setForm((prev: any) => ({ ...prev, tags: prev.tags.filter((t: string) => t !== tag) }));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const res = await fetchTk(`/api/pets/${pet.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: token },
+      body: JSON.stringify(form),
+    });
+    if (res.ok) {
+      alert("Pet atualizado com sucesso!");
+      if (onSuccess) onSuccess();
+    } else {
+      const text = await res.text();
+      alert("Erro ao atualizar pet: " + text);
+    }
+  };
+
+  return (
+    <Container>
+      <form onSubmit={handleSubmit}>
+        <h1>Editar Pet</h1>
+        <input name="nome" className="input" value={form.nome} onChange={handleChange} />
+        <textarea name="descricao" className="input" value={form.descricao} onChange={handleChange} />
+        <input name="tipo" className="input" value={form.tipo} onChange={handleChange} />
+        <div className="tag-input-wrapper">
+          <input
+            name="tags"
+            placeholder="Digite e pressione ,"
+            value={tagInput}
+            onChange={handleTagInput}
+            className="input"
+          />
+          {form.tags.length > 0 && (
+            <div className="tags">
+              {form.tags.map((t: string) => (
+                <TagChip key={t} label={t} onRemove={() => removeTag(t)} />
+              ))}
+            </div>
+          )}
+        </div>
+        <input name="localizacao.pais" className="input" placeholder="País" value={form.localizacao.pais} onChange={handleChange} />
+        <input name="localizacao.estado" className="input" placeholder="Estado" value={form.localizacao.estado} onChange={handleChange} />
+        <input name="localizacao.cidade" className="input" placeholder="Cidade" value={form.localizacao.cidade} onChange={handleChange} />
+        <input name="localizacao.bairro" className="input" placeholder="Bairro" value={form.localizacao.bairro} onChange={handleChange} />
+        <input name="localizacao.rua" className="input" placeholder="Rua" value={form.localizacao.rua} onChange={handleChange} />
+        <input name="localizacao.numero" className="input" placeholder="Número" value={form.localizacao.numero} onChange={handleChange} />
+        <input name="localizacao.cep" className="input" placeholder="CEP" value={form.localizacao.cep} onChange={handleChange} />
+        <button type="submit" className="submit">Salvar</button>
+      </form>
+    </Container>
+  );
+}
+

--- a/frontend/components/EditPetForm/styles.ts
+++ b/frontend/components/EditPetForm/styles.ts
@@ -1,0 +1,92 @@
+import styled, { DefaultTheme, css } from 'styled-components';
+
+export const Container = styled.div`
+  ${({ theme }: { theme: DefaultTheme }) => css`
+    min-height: ${theme.height.sectionHeight};
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: ${theme.spacings.large};
+
+    & form {
+      width: 100%;
+      max-width: 600px;
+      background: ${theme.colors.secondaryBg};
+      padding: ${theme.spacings.large};
+      border-radius: ${theme.radius.big};
+      box-shadow: 0 2px 8px ${theme.colors.shadowColor};
+      display: flex;
+      flex-direction: column;
+      gap: ${theme.spacings.small};
+    }
+
+    & h1 {
+      margin-bottom: ${theme.spacings.small};
+      text-align: center;
+    }
+
+    & .input {
+      padding: ${theme.spacings.xsmall};
+      border-radius: ${theme.radius.small};
+      border: 1px solid ${theme.colors.borderColor};
+      background: ${theme.colors.mainBg};
+      color: ${theme.colors.secondaryColor};
+    }
+
+    & .image-wrapper {
+      display: flex;
+      justify-content: center;
+    }
+
+    & .preview {
+      max-width: 100%;
+      max-height: 200px;
+      border-radius: ${theme.radius.small};
+    }
+
+    & .tag-input-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: ${theme.spacings.xsmall};
+    }
+
+    & .tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: ${theme.spacings.xsmall};
+    }
+
+    & .submit {
+      padding: ${theme.spacings.small};
+      border-radius: ${theme.radius.small};
+      background: ${theme.colors.orange};
+      color: ${theme.colors.secondaryColor};
+      font-weight: bold;
+      cursor: pointer;
+      transition: ${theme.transitions.default};
+    }
+
+    & .submit:hover {
+      background: ${theme.colors.midBrown};
+    }
+
+    & .nav {
+      padding: ${theme.spacings.xsmall};
+      border-radius: ${theme.radius.small};
+      background: ${theme.colors.secondaryBgDarker};
+      color: ${theme.colors.secondaryColor};
+      cursor: pointer;
+      transition: ${theme.transitions.default};
+    }
+
+    & .nav:hover {
+      background: ${theme.colors.secondaryBg};
+    }
+
+    & .actions {
+      display: flex;
+      justify-content: space-between;
+      gap: ${theme.spacings.small};
+    }
+  `}
+`;

--- a/frontend/components/Menu/index.tsx
+++ b/frontend/components/Menu/index.tsx
@@ -15,11 +15,7 @@ export const Menu = () => {
     {
       children: "pets para adoção",
       link: "/allPets",
-    },
-    {
-      children: "meus pets",
-      link: "/myPets",
-    },
+    }
   ];
 
   return (

--- a/frontend/components/Menu/index.tsx
+++ b/frontend/components/Menu/index.tsx
@@ -16,6 +16,10 @@ export const Menu = () => {
       children: "pets para adoção",
       link: "/allPets",
     },
+    {
+      children: "meus pets",
+      link: "/myPets",
+    },
   ];
 
   return (

--- a/frontend/components/SingButtons/index.jsx
+++ b/frontend/components/SingButtons/index.jsx
@@ -8,6 +8,7 @@ import { signOut as firebaseSignOut } from 'firebase/auth';
 import { PageContext } from '@/context/PageContext';
 import defaultIcon from "@/assets/img/default_user_photo.png";
 import { useRouter } from 'next/navigation';
+import { SafeImage } from '../SafeImage';
 
 
 export const SignButtons = () => {
@@ -53,7 +54,7 @@ export const SignButtons = () => {
             </button>
 
             <Link href='/profile' className='sm:flex hidden' style={{ alignContent: "center", alignItems: "center" }} >
-              <Image
+              <SafeImage
                 src={user?.photoURL ?? defaultIcon}
                 width={37}
                 height={37}
@@ -77,7 +78,7 @@ export const SignButtons = () => {
       <div className='sm:hidden flex relative'>
         {userId ? (
           <div className='flex flex-col items-end'>
-            <Image
+            <SafeImage
               src={user?.photoURL ?? defaultIcon}
               width={37}
               height={37}
@@ -89,7 +90,7 @@ export const SignButtons = () => {
             {toggleDropdown && (
               <div className='dropdown text-center'>
                 <Link
-                  href='/profile'
+                  href='/myPets'
                   className='dropdown_link'
                   onClick={() => setToggleDropdown(false)}
                 >


### PR DESCRIPTION
## Summary
- allow pets to be updated in backend
- expose PUT endpoint `/api/pets/{id}`
- add EditPetForm component
- list pets of logged-in user and edit them
- link "meus pets" in menu

## Testing
- `./mvnw -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6860845fef7c83289280199e1d1c7b52