### PR TITLE
Remove grayscale filter from images

### DIFF
--- a/frontend/components/SafeImage/index.tsx
+++ b/frontend/components/SafeImage/index.tsx
@@ -33,7 +33,6 @@ export const SafeImage = ({ src, text, width = 40, height, className, alt, onCli
       {!imageError ? (
         <div className={theme.isLight ? "invert" : "" + (className || "")}>
           <Image
-            className="grayscale"
             unoptimized
             src={src}
             alt={alt ?? text ?? "no description"}


### PR DESCRIPTION
## Summary
- ensure `SafeImage` component doesn't force black-and-white images

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68609c5046ec8328b5e1d671367fe399