### PR TITLE
Implement form validation and bottom alerts

### DIFF
--- a/frontend/app/petForm/page.tsx
+++ b/frontend/app/petForm/page.tsx
@@ -1,8 +1,23 @@
 "use client";
 
 import AddPetForm from "@/components/AddPetForm/AddPetForm";
+import { useContext, useEffect } from "react";
+import { PageContext } from "@/context/PageContext";
+import { useRouter } from "next/navigation";
+import { useAlert } from "@/context/AlertContext";
 
 export default function PetFormPage() {
-  return <AddPetForm />;
+  const { userId } = useContext(PageContext);
+  const { showAlert } = useAlert();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!userId) {
+      showAlert("Usuário não autenticado", "error");
+      router.push("/login");
+    }
+  }, [userId, router, showAlert]);
+
+  return userId ? <AddPetForm /> : null;
 }
 

--- a/frontend/components/AddPetForm/AddPetForm.tsx
+++ b/frontend/components/AddPetForm/AddPetForm.tsx
@@ -3,6 +3,7 @@
 import { ChangeEvent, FormEvent, KeyboardEvent, useContext, useState, useEffect } from "react";
 import { PageContext } from "@/context/PageContext";
 import { useAlert } from "@/context/AlertContext";
+import { useRouter } from "next/navigation";
 import { fetchTk } from "@/lib/helper";
 import { Container } from "./styles";
 import { TagChip } from "../TagChip";
@@ -53,8 +54,9 @@ type FormState = {
 };
 
 export default function AddPetForm() {
-  const { token } = useContext(PageContext);
+  const { token, userId } = useContext(PageContext);
   const { showAlert } = useAlert();
+  const router = useRouter();
   const [form, setForm] = useState<FormState>({
     nome: "",
     descricao: "",
@@ -77,6 +79,13 @@ export default function AddPetForm() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
+
+  useEffect(() => {
+    if (!userId) {
+      showAlert("Usuário não autenticado", "error");
+      router.push("/login");
+    }
+  }, [userId, router, showAlert]);
 
   const handleChange = (
     e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -215,6 +224,12 @@ export default function AddPetForm() {
     e.preventDefault();
     setLoading(true);
     setError(null);
+    if (!userId) {
+      showAlert("Usuário não autenticado", "error");
+      router.push("/login");
+      setLoading(false);
+      return;
+    }
     if (!validateStep1()) {
       setLoading(false);
       return;
@@ -307,7 +322,7 @@ export default function AddPetForm() {
           <>
             <input
               name="nome"
-              placeholder="Nome"
+              placeholder="Nome *"
               value={form.nome}
               onChange={handleChange}
               required
@@ -327,14 +342,17 @@ export default function AddPetForm() {
               required
               className="input"
             >
-              <option value="">Selecione o tipo</option>
+              <option value="">Selecione o tipo *</option>
               {tiposDeAnimais.map((t) => (
                 <option key={t} value={t}>
                   {t}
                 </option>
               ))}
             </select>
-            <input type="file" name="imagem" onChange={handleImageChange} required className="input" />
+            <label>
+              Imagem *
+              <input type="file" name="imagem" onChange={handleImageChange} required className="input" />
+            </label>
             {imagePreview && (
               <div className="image-wrapper">
                 <img src={imagePreview} alt="Pré-visualização" className="preview" />
@@ -372,7 +390,7 @@ export default function AddPetForm() {
           <>
             <input
               name="cep"
-              placeholder="CEP"
+              placeholder="CEP *"
               value={form.cep}
               onChange={handleCepChange}
               required
@@ -380,7 +398,7 @@ export default function AddPetForm() {
             />
             <input
               name="pais"
-              placeholder="País"
+              placeholder="País *"
               value={form.pais}
               onChange={handleChange}
               required
@@ -388,7 +406,7 @@ export default function AddPetForm() {
             />
             <input
               name="estado"
-              placeholder="Estado"
+              placeholder="Estado *"
               value={form.estado}
               onChange={handleChange}
               required
@@ -396,7 +414,7 @@ export default function AddPetForm() {
             />
             <input
               name="cidade"
-              placeholder="Cidade"
+              placeholder="Cidade *"
               value={form.cidade}
               onChange={handleChange}
               required
@@ -404,7 +422,7 @@ export default function AddPetForm() {
             />
             <input
               name="bairro"
-              placeholder="Bairro"
+              placeholder="Bairro *"
               value={form.bairro}
               onChange={handleChange}
               required
@@ -412,7 +430,7 @@ export default function AddPetForm() {
             />
             <input
               name="rua"
-              placeholder="Rua"
+              placeholder="Rua *"
               value={form.rua}
               onChange={handleChange}
               required
@@ -420,7 +438,7 @@ export default function AddPetForm() {
             />
             <input
               name="numero"
-              placeholder="Número"
+              placeholder="Número *"
               value={form.numero}
               onChange={handleChange}
               required

--- a/frontend/components/AlertMessage/index.tsx
+++ b/frontend/components/AlertMessage/index.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { ReactElement } from "react";
+import * as Styled from "./styles";
+import { AlertType } from "@/context/AlertContext";
+
+export interface AlertMessageProps {
+  message: string;
+  type?: AlertType;
+}
+
+export const AlertMessage = ({ message, type = "error" }: AlertMessageProps): ReactElement => {
+  return <Styled.Container data-type={type}>{message}</Styled.Container>;
+};

--- a/frontend/components/AlertMessage/styles.ts
+++ b/frontend/components/AlertMessage/styles.ts
@@ -1,0 +1,29 @@
+"use client";
+import styled, { css, DefaultTheme } from "styled-components";
+import { AlertType } from "@/context/AlertContext";
+
+const typeColor = (theme: DefaultTheme, type: AlertType) => {
+  switch (type) {
+    case "success":
+      return theme.colors.successfulGreen;
+    case "info":
+      return theme.colors.lightBlue;
+    default:
+      return theme.colors.dangerColor;
+  }
+};
+
+export const Container = styled.div<{ "data-type": AlertType }>`
+  ${({ theme, "data-type": type }: { theme: DefaultTheme; "data-type": AlertType }) => css`
+    position: fixed;
+    bottom: ${theme.spacings.small};
+    left: 50%;
+    transform: translateX(-50%);
+    background: ${typeColor(theme, type)};
+    color: ${theme.colors.secondaryColor};
+    padding: ${theme.spacings.small} ${theme.spacings.medium};
+    border-radius: ${theme.radius.big};
+    box-shadow: 0 2px 8px ${theme.colors.shadowColor};
+    z-index: 1000;
+  `}
+`;

--- a/frontend/components/EditPetForm/EditPetForm.tsx
+++ b/frontend/components/EditPetForm/EditPetForm.tsx
@@ -4,6 +4,7 @@ import { ChangeEvent, FormEvent, useState } from "react";
 import { fetchTk } from "@/lib/helper";
 import { Container } from "./styles";
 import { TagChip } from "../TagChip";
+import { useAlert } from "@/context/AlertContext";
 
 export interface EditPetFormProps {
   pet: any;
@@ -12,6 +13,7 @@ export interface EditPetFormProps {
 }
 
 export default function EditPetForm({ pet, token, onSuccess }: EditPetFormProps) {
+  const { showAlert } = useAlert();
   const [form, setForm] = useState<any>({
     nome: pet.nome || "",
     descricao: pet.descricao || "",
@@ -69,11 +71,11 @@ export default function EditPetForm({ pet, token, onSuccess }: EditPetFormProps)
       body: JSON.stringify(form),
     });
     if (res.ok) {
-      alert("Pet atualizado com sucesso!");
+      showAlert("Pet atualizado com sucesso!", "success");
       if (onSuccess) onSuccess();
     } else {
       const text = await res.text();
-      alert("Erro ao atualizar pet: " + text);
+      showAlert("Erro ao atualizar pet: " + text, "error");
     }
   };
 

--- a/frontend/components/LoginForm/index.tsx
+++ b/frontend/components/LoginForm/index.tsx
@@ -10,12 +10,14 @@ import { getUserByFirebaseUserId } from '@/lib/helper';
 import { PageContext } from '@/context/PageContext';
 import { Container } from './styles';
 import { SafeImage } from '../SafeImage';
+import { useAlert } from '@/context/AlertContext';
 
 export const LoginForm = () => {
   const router = useRouter();
   const [form, setForm] = useState({ email: '', password: '' });
   const [loading, setLoading] = useState(false);
   const { handleLogin, updateSessionId, updateToken, updateUser } = useContext(PageContext);
+  const { showAlert } = useAlert();
 
   useEffect(() => {
     const checkRedirect = async () => {
@@ -42,7 +44,8 @@ export const LoginForm = () => {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (!form.email || !form.password) {
-      return alert('Preencha email e senha.');
+      showAlert('Preencha email e senha.', 'error');
+      return;
     }
 
     setLoading(true);
@@ -51,7 +54,7 @@ export const LoginForm = () => {
       router.push('/');
     } catch (err) {
       console.error("handleSubmit", err);
-      alert('Erro ao fazer login');
+      showAlert('Erro ao fazer login', 'error');
     } finally {
       setLoading(false);
     }
@@ -68,7 +71,7 @@ export const LoginForm = () => {
       }
     } catch (err) {
       console.error("handleGoogleLogin", err);
-      alert('Erro ao fazer login com Google');
+      showAlert('Erro ao fazer login com Google', 'error');
     }
   };
 

--- a/frontend/components/Provider/Provider.tsx
+++ b/frontend/components/Provider/Provider.tsx
@@ -6,6 +6,7 @@ import { GlobalStyles } from "@/styles/globalStyles";
 import StyledComponentsRegistry from '@/lib/registry';
 import useI18n from '@/hooks/useI18n';
 import { PageProvider } from '@/context/PageContext';
+import { AlertProvider } from '@/context/AlertContext';
 import { DefaultTheme } from 'styled-components';
 
 interface ThemeContextType {
@@ -55,7 +56,9 @@ export const Provider = ({ children }: { children: ReactNode }): ReactElement =>
         <ThemeProvider theme={currentTheme}>
           <GlobalStyles />
           <PageProvider>
-            {children}
+            <AlertProvider>
+              {children}
+            </AlertProvider>
           </PageProvider>
         </ThemeProvider>
       </ThemeContext.Provider>

--- a/frontend/context/AlertContext.tsx
+++ b/frontend/context/AlertContext.tsx
@@ -1,0 +1,36 @@
+import { createContext, useCallback, useContext, useState, ReactNode } from "react";
+import ClientPortal from "@/components/Portal";
+import { AlertMessage } from "@/components/AlertMessage";
+
+export type AlertType = "success" | "error" | "info";
+
+type Alert = { message: string; type?: AlertType } | null;
+
+interface AlertContextProps {
+  showAlert: (message: string, type?: AlertType) => void;
+}
+
+const AlertContext = createContext<AlertContextProps>({
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  showAlert: () => {},
+});
+
+export const useAlert = () => useContext(AlertContext);
+
+export const AlertProvider = ({ children }: { children: ReactNode }) => {
+  const [alert, setAlert] = useState<Alert>(null);
+
+  const showAlert = useCallback((message: string, type: AlertType = "error") => {
+    setAlert({ message, type });
+    setTimeout(() => setAlert(null), 4000);
+  }, []);
+
+  return (
+    <AlertContext.Provider value={{ showAlert }}>
+      {children}
+      <ClientPortal>
+        {alert && <AlertMessage message={alert.message} type={alert.type} />}
+      </ClientPortal>
+    </AlertContext.Provider>
+  );
+};


### PR DESCRIPTION
## Summary
- implement global alert context
- display alerts at the bottom of the page
- validate pet form images and required fields
- replace window.alert with alert context

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68609cebc44c8328b10926a0576134b2