### PR TITLE
Display nearby pets on home page

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,30 +1,86 @@
-'use client';
+"use client";
 
-import { useEffect, useState, useContext } from 'react';
+import { useEffect, useState } from "react";
 import { Section } from "@/components/Section";
-import { PageContext } from "@/context/PageContext";
 import { LoadingSection } from "@/components/LoadingSection";
-import { fetchTk } from '@/lib/helper';
+import { PetCard } from "@/components/PetCard";
+import { fetchTk, distanceKm, Coordinates } from "@/lib/helper";
+
+interface Pet {
+  id: string;
+  nome: string;
+  descricao?: string;
+  tipo?: string;
+  tags?: string[];
+  imagem?: string;
+  localizacao?: Coordinates;
+}
 
 export default function Home() {
-  const { } = useContext(PageContext);
-  const [msg, setMsg] = useState('');
+  const [pets, setPets] = useState<Pet[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchTk('/api/hello')
-      .then(res => res.text())
-      .then(setMsg)
-      .catch(console.error);
+    let position: Coordinates | null = null;
+
+    const loadPets = async () => {
+      try {
+        const res = await fetchTk("/api/pets");
+        const data: Pet[] = await res.json();
+        let list = data;
+        if (position) {
+          list = data
+            .filter(p => p.localizacao &&
+              typeof p.localizacao.latitude === "number" &&
+              typeof p.localizacao.longitude === "number")
+            .map(p => ({
+              ...p,
+              distance: distanceKm(position as Coordinates, p.localizacao as Coordinates),
+            }))
+            .sort((a, b) => (a.distance ?? Infinity) - (b.distance ?? Infinity));
+        }
+        setPets(list.slice(0, 5));
+      } catch (err) {
+        console.error("fetch pets", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          position = {
+            latitude: pos.coords.latitude,
+            longitude: pos.coords.longitude,
+          };
+          loadPets();
+        },
+        () => loadPets(),
+      );
+    } else {
+      loadPets();
+    }
   }, []);
 
   return (
     <main>
-      <Section>
-        {!msg ?
+      <Section type="centered">
+        <div>
+          <h2>Adote seu novo amigo</h2>
+          <p>Encontre pets disponíveis para adoção perto de você.</p>
+        </div>
+      </Section>
+      <Section type="flex-list">
+        {loading ? (
           <LoadingSection />
-          :
-          <h1>{msg}</h1>
-        }
+        ) : (
+          pets.map((pet) => (
+            <div key={pet.id}>
+              <PetCard pet={pet} />
+            </div>
+          ))
+        )}
       </Section>
     </main>
   );

--- a/frontend/lib/helper.ts
+++ b/frontend/lib/helper.ts
@@ -58,3 +58,21 @@ export async function getUserByFirebaseUserId({
   }
   return res.json();
 }
+
+export interface Coordinates {
+  latitude: number;
+  longitude: number;
+}
+
+export function distanceKm(a: Coordinates, b: Coordinates): number {
+  const R = 6371; // raio da Terra em km
+  const lat1 = (a.latitude * Math.PI) / 180;
+  const lat2 = (b.latitude * Math.PI) / 180;
+  const dLat = lat2 - lat1;
+  const dLon = ((b.longitude - a.longitude) * Math.PI) / 180;
+  const h =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(lat1) * Math.cos(lat2) *
+    Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  return 2 * R * Math.asin(Math.sqrt(h));
+}


### PR DESCRIPTION
## Summary
- add helper to compute haversine distance
- update homepage to fetch pets, show nearby ones and description

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*
- `./mvnw -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68609d3d26008328b5d3d4b0b526f46b