### PR TITLE
Implement dark mode toggle with Tailwind

### DIFF
--- a/frontend/components/Footer/styles.ts
+++ b/frontend/components/Footer/styles.ts
@@ -5,8 +5,8 @@ import { responsiveFontSize } from '../../styles/helper';
 export const Container = styled.footer`
   ${({ theme }: { theme: DefaultTheme }) => css`
       min-height: ${theme.height.footerHeight};
-      background: ${theme.colors.black};
-      background: ${theme.gradient.darkGreyGradient};
+      background: ${theme.colors.mainBg};
+      color: ${theme.colors.secondaryColor};
       display: flex;
       flex-wrap: wrap;
       align-items: center;

--- a/frontend/components/Header/index.tsx
+++ b/frontend/components/Header/index.tsx
@@ -14,7 +14,7 @@ export const Header = (): ReactElement => {
   return (
       <Container className='flex '>
         <MainLogo />
-        <div className="max-sm:hidden">
+        <div className="hidden sm:block">
           <Menu />
         </div>
         <div className='text-[1.5rem] flex gap-4 '>
@@ -23,7 +23,7 @@ export const Header = (): ReactElement => {
             {isLight ? "Dark 🌑" : "Light ☀"}
           </button>
         </div>
-        <div className="hidden max-sm:block" style={{ width: "100%" }}>
+        <div className="block sm:hidden" style={{ width: "100%" }}>
           <Menu />
         </div>
 

--- a/frontend/components/Header/index.tsx
+++ b/frontend/components/Header/index.tsx
@@ -19,7 +19,9 @@ export const Header = (): ReactElement => {
         </div>
         <div className='text-[1.5rem] flex gap-4 '>
           <SignButtons  />
-          <button   onClick={changeTheme}>{isLight ? "Dark 🌑" : "Light ☀"}</button>
+          <button onClick={changeTheme} className="p-2 rounded bg-gray-200 dark:bg-gray-700">
+            {isLight ? "Dark 🌑" : "Light ☀"}
+          </button>
         </div>
         <div className="hidden max-sm:block" style={{ width: "100%" }}>
           <Menu />

--- a/frontend/components/Header/styles.ts
+++ b/frontend/components/Header/styles.ts
@@ -10,10 +10,9 @@ export const Container = styled.header`
     height: ${theme.height.headerheight};
     min-width: fit-content;
     overflow: hidden;
-    color: ${theme.colors.mainColor};
+    color: ${theme.colors.secondaryColor};
     padding: ${theme.spacings.medium};
-    background: ${theme.colors.black};
-    background: ${theme.gradient.darkGreyGradient};
+    background: ${theme.colors.mainBg};
     box-shadow: 0 1px 20px rgba(255, 255, 255, 0.2);
     backdrop-filter: blur(5px);
     -webkit-backdrop-filter: blur(5px);

--- a/frontend/components/Provider/Provider.tsx
+++ b/frontend/components/Provider/Provider.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { createContext, ReactElement, ReactNode, useContext, useEffect, useState } from 'react';
 import { ThemeProvider } from "styled-components";
-import { theme, themeLight } from "@/styles/theme";
+import { themeDark, themeLight } from "@/styles/theme";
 import { GlobalStyles } from "@/styles/globalStyles";
 import StyledComponentsRegistry from '@/lib/registry';
 import useI18n from '@/hooks/useI18n';
@@ -27,27 +27,31 @@ export const useThemeContext = () => {
 export const Provider = ({ children }: { children: ReactNode }): ReactElement => {
   useI18n();
   // const [mounted, setMounted] = useState(false);
-  const [currentTheme, setCurrentTheme] = useState<DefaultTheme>(theme);
+  const [currentTheme, setCurrentTheme] = useState<DefaultTheme>(themeDark);
 
   const [isLight, setIsLight] = useState<boolean>(false);
 
-  // useEffect(() => {
-  //   setMounted(true);
-  //   const savedTheme = localStorage.getItem("IsLight");
-  //   if (savedTheme) {
-  //     setIsLight(JSON.parse(savedTheme));
-  //   }
-  // }, []);
   useEffect(() => {
-    setCurrentTheme(isLight ? themeLight : theme);
+    const savedTheme = localStorage.getItem("IsLight");
+    if (savedTheme !== null) {
+      setIsLight(JSON.parse(savedTheme));
+    }
+  }, []);
+
+  useEffect(() => {
+    setCurrentTheme(isLight ? themeLight : themeDark);
+    const root = document.documentElement;
+    if (isLight) {
+      root.classList.remove("dark");
+    } else {
+      root.classList.add("dark");
+    }
+    localStorage.setItem("IsLight", JSON.stringify(isLight));
   }, [isLight]);
 
 
   const changeTheme = () => {
-    const newTheme = !isLight;
-
-    setIsLight(newTheme);
-    localStorage.setItem("IsLight", JSON.stringify(newTheme));
+    setIsLight((prev) => !prev);
   };
 
   return (

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,6 +1,6 @@
 const config = {
   plugins: {
-    tailwindcss: {},
+    "@tailwindcss/postcss": {},
     autoprefixer: {},
   },
 };

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,5 +1,8 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 };
 
 export default config;

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -5,3 +5,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-white text-black dark:bg-gray-900 dark:text-gray-100;
+}

--- a/frontend/styles/theme.ts
+++ b/frontend/styles/theme.ts
@@ -1,6 +1,6 @@
 import { Colors } from "./COLORS";
 
-export const theme = {
+export const themeDark = {
   colors: {
     ...Colors,
   },
@@ -96,5 +96,14 @@ export const theme = {
 } as const;
 
 export const themeLight = {
-  ...theme
+  ...themeDark,
+  colors: {
+    ...themeDark.colors,
+    mainBg: Colors.white,
+    secondaryColor: Colors.mainColor,
+    secondaryBg: Colors.lightGray,
+    secondaryBgDarker: '#e5e5e5',
+  },
 } as const;
+
+export { themeDark as theme };

--- a/frontend/tailwind.config.mjs
+++ b/frontend/tailwind.config.mjs
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: 'class',
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind with dark mode
- expose dark and light themes
- toggle the `dark` class on theme change and store preference
- style page background with Tailwind dark classes
- update the theme switch button style

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861754f1d508328ab8a55ac37ee94db