### PR TITLE
Add multi-image support for pets

### DIFF
--- a/backend/src/main/java/com/example/backend/models/Pet.java
+++ b/backend/src/main/java/com/example/backend/models/Pet.java
@@ -10,6 +10,7 @@ public class Pet {
     private Localizacao localizacao;
     private String userId;
     private String imagem;
+    private List<String> imagens;
     private String email;
     private String telefone;
 
@@ -62,6 +63,14 @@ public class Pet {
 
     public void setImagem(String imagem) {
         this.imagem = imagem;
+    }
+
+    public List<String> getImagens() {
+        return imagens;
+    }
+
+    public void setImagens(List<String> imagens) {
+        this.imagens = imagens;
     }
 
     public String getEmail() {

--- a/frontend/app/allPets/page.tsx
+++ b/frontend/app/allPets/page.tsx
@@ -16,6 +16,7 @@ interface Pet {
   tipo?: string;
   tags?: string[];
   imagem?: string;
+  imagens?: string[];
   matchTags?: string[];
   missingTags?: string[];
 }

--- a/frontend/app/editPet/[id]/page.tsx
+++ b/frontend/app/editPet/[id]/page.tsx
@@ -12,6 +12,7 @@ interface Pet {
   tipo?: string;
   tags?: string[];
   imagem?: string;
+  imagens?: string[];
   localizacao?: Record<string, any>;
 }
 

--- a/frontend/app/myPets/page.tsx
+++ b/frontend/app/myPets/page.tsx
@@ -14,6 +14,7 @@ interface Pet {
   tipo?: string;
   tags?: string[];
   imagem?: string;
+  imagens?: string[];
 }
 
 export default function MyPetsPage() {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -13,6 +13,7 @@ interface Pet {
   tipo?: string;
   tags?: string[];
   imagem?: string;
+  imagens?: string[];
   localizacao?: Coordinates;
 }
 

--- a/frontend/app/pet/[id]/page.tsx
+++ b/frontend/app/pet/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { Section } from "@/components/Section";
 import { LoadingSection } from "@/components/LoadingSection";
 import { SafeImage } from "@/components/SafeImage";
+import { Carousel } from "@/components/Carousel";
 import { TagChip } from "@/components/TagChip";
 import { fetchTk } from "@/lib/helper";
 import * as Styled from "./styles";
@@ -15,6 +16,7 @@ type Pet = {
   tipo?: string;
   tags?: string[];
   imagem?: string;
+  imagens?: string[];
   localizacao?: Record<string, any>;
   email?: string;
   telefone?: string;
@@ -35,19 +37,31 @@ export default function PetPage({ params }: { params: { id: string } }) {
 
   if (loading) return <LoadingSection />;
   if (!pet) return <Section>Pet não encontrado</Section>;
+  const imagens = pet.imagens && pet.imagens.length > 0
+    ? pet.imagens
+    : pet.imagem
+    ? [pet.imagem]
+    : [];
 
   return (
     <Section>
       <Styled.Container>
         <h1>{pet.nome}</h1>
-        <div className="image-wrapper">
-          <SafeImage
-            src={pet.imagem ?? "https://via.placeholder.com/300x200"}
-            text={pet.nome}
-            width={400}
-            height={300}
-          />
-        </div>
+        {imagens.length > 0 && (
+          <div className="image-wrapper">
+            <Carousel
+              items={imagens.map((src) => (
+                <SafeImage
+                  key={src}
+                  src={src}
+                  text={pet.nome}
+                  width={400}
+                  height={300}
+                />
+              ))}
+            />
+          </div>
+        )}
         {pet.tipo && <p>Tipo: {pet.tipo}</p>}
         {pet.descricao && <p>{pet.descricao}</p>}
         {pet.tags && pet.tags.length > 0 && (

--- a/frontend/components/Carousel/index.tsx
+++ b/frontend/components/Carousel/index.tsx
@@ -14,15 +14,15 @@ export const Carousel = ({ items, bottomComponent }: CarouselProps): ReactElemen
 
   return (
     <Container>
-      <div>
-        {items[index]}
-      </div>
-      <CarouselSelector 
-        indexCarousel={index}
-        setIndex={setIndex}
-        itemsLength={max}
-      />
+      <div>{items[index]}</div>
+      {max > 1 && (
+        <CarouselSelector
+          indexCarousel={index}
+          setIndex={setIndex}
+          itemsLength={max}
+        />
+      )}
       {bottomComponent}
     </Container>
-  )
+  );
 };

--- a/frontend/components/EditPetForm/EditPetForm.tsx
+++ b/frontend/components/EditPetForm/EditPetForm.tsx
@@ -24,7 +24,7 @@ export default function EditPetForm({ pet, token, onSuccess }: EditPetFormProps)
     cep: pet.localizacao?.cep ?? "",
     latitude: String(pet.localizacao?.latitude ?? ""),
     longitude: String(pet.localizacao?.longitude ?? ""),
-    imagem: null,
+    imagens: [],
   };
   return (
     <PetForm
@@ -33,7 +33,7 @@ export default function EditPetForm({ pet, token, onSuccess }: EditPetFormProps)
       token={token}
       buttonLabel="Salvar"
       initialData={initial}
-      imageUrl={pet.imagem ?? null}
+      imageUrl={pet.imagens?.[0] ?? pet.imagem ?? null}
       onSuccess={onSuccess}
     />
   );

--- a/frontend/components/PetCard/index.tsx
+++ b/frontend/components/PetCard/index.tsx
@@ -10,17 +10,19 @@ export interface PetCardProps {
     tipo?: string;
     tags?: string[];
     imagem?: string;
+    imagens?: string[];
     matchTags?: string[];
     missingTags?: string[];
   };
 }
 
 export const PetCard = ({ pet }: PetCardProps) => {
+  const imgSrc = pet.imagens?.[0] ?? pet.imagem ?? "https://via.placeholder.com/300x200";
   return (
     <Styled.Container>
       <Styled.ImageWrapper>
         <SafeImage
-          src={pet.imagem ?? "https://via.placeholder.com/300x200"}
+          src={imgSrc}
           text={pet.nome}
           width={300}
           height={200}

--- a/frontend/components/PetFormParts/ImageInput.tsx
+++ b/frontend/components/PetFormParts/ImageInput.tsx
@@ -2,17 +2,19 @@
 import { ChangeEvent } from "react";
 
 export interface ImageInputProps {
-  preview: string | null;
+  previews: string[];
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
-export default function ImageInput({ preview, onChange }: ImageInputProps) {
+export default function ImageInput({ previews, onChange }: ImageInputProps) {
   return (
     <>
-      <input type="file" name="imagem" onChange={onChange} className="input" />
-      {preview && (
+      <input type="file" name="imagens" onChange={onChange} multiple className="input" />
+      {previews.length > 0 && (
         <div className="image-wrapper">
-          <img src={preview} alt="Pré-visualização" className="preview" />
+          {previews.map((src, i) => (
+            <img key={i} src={src} alt="Pré-visualização" className="preview" />
+          ))}
         </div>
       )}
     </>


### PR DESCRIPTION
## Summary
- allow `Pet` to hold multiple image URLs
- update carousel to hide controls if only one image
- enable multi-image upload in `PetForm`
- show first image on cards and list pages
- display all pet images in a carousel on the detail page

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'styled-components')*
- `./mvnw -q test` *(fails: could not fetch Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6861752681cc8328849e1dd9f42e6c80