### PR TITLE
Enable light/dark theme switch

### DIFF
--- a/frontend/components/DropDown/DropDown.tsx
+++ b/frontend/components/DropDown/DropDown.tsx
@@ -3,13 +3,14 @@ import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
 import { Container } from './styles';
 import { IconSpan } from '../IconSpan';
 import { DropDownProps, Styling } from './types';
-import { theme } from '@/styles/theme';
+import { useTheme } from 'styled-components';
 import { DropDownList } from './DropDownList';
 
 export const DropDown = ({ children, dropDownId, toggleId, items, height, style }: DropDownProps): ReactElement => {
   const [isOpen, setIsOpen] = useState(false);
   const [sizing, setSizing] = useState<Styling>({});
   const containerRef = useRef<HTMLDivElement>(null);
+  const theme = useTheme();
 
   const toggle = useCallback(() => {
     setIsOpen(prev => !prev);
@@ -28,7 +29,7 @@ export const DropDown = ({ children, dropDownId, toggleId, items, height, style 
         background: window.getComputedStyle(containerRef.current).background ?? theme.colors.mainBg,
         padding: window.getComputedStyle(containerRef.current).padding,
         outline: window.getComputedStyle(containerRef.current?.parentElement as Element)?.border,
-        boxShadow: '0px 0px 8px 0px #000000d8 inset',
+        boxShadow: `0px 0px 8px 0px ${theme.colors.shadowColor} inset`,
         listStyle: 'none',
         ...(style || {}),
       };

--- a/frontend/components/DropDown/styles.ts
+++ b/frontend/components/DropDown/styles.ts
@@ -17,7 +17,7 @@ export const Container = styled.div<ContainerProps>`
     border-top-right-radius: 4px;
     border-top-left-radius: 4px;
     margin: 0px 5px;
-    box-shadow: 0px 0px 8px 0px #000000d8 inset;
+    box-shadow: 0px 0px 8px 0px ${theme.colors.shadowColor} inset;
 
     & button {
       display: flex;

--- a/frontend/components/LoginForm/styles.ts
+++ b/frontend/components/LoginForm/styles.ts
@@ -35,7 +35,7 @@ export const Container = styled.div`
 `;
 
 export const Input = styled.input`
-  border: 1px solid #ccc;
+  border: 1px solid ${({ theme }) => theme.colors.lightGrey};
   padding: 12px;
   width: 100%;
   border-radius: 6px;

--- a/frontend/components/Provider/Provider.tsx
+++ b/frontend/components/Provider/Provider.tsx
@@ -30,14 +30,12 @@ export const Provider = ({ children }: { children: ReactNode }): ReactElement =>
   const [currentTheme, setCurrentTheme] = useState<DefaultTheme>(theme);
 
   const [isLight, setIsLight] = useState<boolean>(false);
-
-  // useEffect(() => {
-  //   setMounted(true);
-  //   const savedTheme = localStorage.getItem("IsLight");
-  //   if (savedTheme) {
-  //     setIsLight(JSON.parse(savedTheme));
-  //   }
-  // }, []);
+  useEffect(() => {
+    const savedTheme = localStorage.getItem("IsLight");
+    if (savedTheme) {
+      setIsLight(JSON.parse(savedTheme));
+    }
+  }, []);
   useEffect(() => {
     setCurrentTheme(isLight ? themeLight : theme);
   }, [isLight]);

--- a/frontend/components/Register/index.tsx
+++ b/frontend/components/Register/index.tsx
@@ -1,12 +1,23 @@
 import Image from "next/image";
-import google from "../../assets/google.svg"
+import google from "../../assets/google.svg";
 import { SafeImage } from "../SafeImage";
-export const Register=()=>{
-  
+import styled, { useTheme } from "styled-components";
+
+const Input = styled.input`
+  padding-left: 2rem;
+  height: 3rem;
+  width: 100%;
+  border-bottom: 2px solid ${({ theme }) => theme.colors.blueGray};
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.blueGray};
+  }
+`;
+export const Register = () => {
+  const theme = useTheme();
 
   return <>
-    <div className="h-screen bg-slate-100 flex justify-center items-center">
-      <main className="w-[475px]  p-16 bg-white shadow-lg rounded-md">
+    <div className="h-screen flex justify-center items-center" style={{ background: theme.colors.secondaryBg }}>
+      <main className="w-[475px]  p-16 shadow-lg rounded-md" style={{ background: theme.colors.mainBg }}>
 
         <h1 className="mb-12 text-center font-bold text-4xl">Sign Up</h1>
 
@@ -14,28 +25,33 @@ export const Register=()=>{
 
           <label htmlFor="email">Email</label>
           <div className="relative">
-            <svg className="absolute top-2.5" xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="#9caccb" viewBox="0 0 256 256"><path d="M102,152a6,6,0,0,1-6,6H56a6,6,0,0,1,0-12H96A6,6,0,0,1,102,152Zm136-36v60a14,14,0,0,1-14,14H134v34a6,6,0,0,1-12,0V190H32a14,14,0,0,1-14-14V116A58.07,58.07,0,0,1,76,58h78V24a6,6,0,0,1,6-6h32a6,6,0,0,1,0,12H166V58h14A58.07,58.07,0,0,1,238,116ZM122,178V116a46,46,0,0,0-92,0v60a2,2,0,0,0,2,2Zm104-62a46.06,46.06,0,0,0-46-46H166v74a6,6,0,0,1-12,0V70H111.29A57.93,57.93,0,0,1,134,116v62h90a2,2,0,0,0,2-2Z"></path></svg>
-            <input className="block w-full h-12 pl-8 border-b-[2px] border-[#9caccb] placeholder:text-[#9caccb]" placeholder="Insira seu email" type="text" name="email" id="email"/>
+            <svg className="absolute top-2.5" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 256 256" fill={theme.colors.blueGray}><path d="M102,152a6,6,0,0,1-6,6H56a6,6,0,0,1,0-12H96A6,6,0,0,1,102,152Zm136-36v60a14,14,0,0,1-14,14H134v34a6,6,0,0,1-12,0V190H32a14,14,0,0,1-14-14V116A58.07,58.07,0,0,1,76,58h78V24a6,6,0,0,1,6-6h32a6,6,0,0,1,0,12H166V58h14A58.07,58.07,0,0,1,238,116ZM122,178V116a46,46,0,0,0-92,0v60a2,2,0,0,0,2,2Zm104-62a46.06,46.06,0,0,0-46-46H166v74a6,6,0,0,1-12,0V70H111.29A57.93,57.93,0,0,1,134,116v62h90a2,2,0,0,0,2-2Z"/></svg>
+            <Input placeholder="Insira seu email" type="text" name="email" id="email" />
           </div>
 
           <label className="block mt-6" htmlFor="username">Nome</label>
           <div className="relative">
-            <svg className="absolute top-2.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#9caccb" viewBox="0 0 256 256"><path d="M229.19,213c-15.81-27.32-40.63-46.49-69.47-54.62a70,70,0,1,0-63.44,0C67.44,166.5,42.62,185.67,26.81,213a6,6,0,1,0,10.38,6C56.4,185.81,90.34,166,128,166s71.6,19.81,90.81,53a6,6,0,1,0,10.38-6ZM70,96a58,58,0,1,1,58,58A58.07,58.07,0,0,1,70,96Z"></path></svg>
-            <input className="block w-full h-12 pl-8 border-b-[2px] border-[#9caccb] placeholder:text-[#9caccb]" placeholder="Insira seu username" type="text" name="username" id="username"/>
+            <svg className="absolute top-2.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 256 256" fill={theme.colors.blueGray}><path d="M229.19,213c-15.81-27.32-40.63-46.49-69.47-54.62a70,70,0,1,0-63.44,0C67.44,166.5,42.62,185.67,26.81,213a6,6,0,1,0,10.38,6C56.4,185.81,90.34,166,128,166s71.6,19.81,90.81,53a6,6,0,1,0,10.38-6ZM70,96a58,58,0,1,1,58,58A58.07,58.07,0,0,1,70,96Z"/></svg>
+            <Input placeholder="Insira seu username" type="text" name="username" id="username" />
           </div>
 
           <label className="block mt-6" htmlFor="password">Senha</label>
           <div className="relative">
-            <svg className="absolute top-2.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#9caccb" viewBox="0 0 256 256"><path d="M208,82H174V56a46,46,0,0,0-92,0V82H48A14,14,0,0,0,34,96V208a14,14,0,0,0,14,14H208a14,14,0,0,0,14-14V96A14,14,0,0,0,208,82ZM94,56a34,34,0,0,1,68,0V82H94ZM210,208a2,2,0,0,1-2,2H48a2,2,0,0,1-2-2V96a2,2,0,0,1,2-2H208a2,2,0,0,1,2,2Zm-82-94a26,26,0,0,0-6,51.29V184a6,6,0,0,0,12,0V165.29A26,26,0,0,0,128,114Zm0,40a14,14,0,1,1,14-14A14,14,0,0,1,128,154Z"></path></svg>
-            <input className="block w-full h-12 pl-8 border-b-[2px] border-[#9caccb] placeholder:text-[#9caccb]" placeholder="Insira sua senha" type="password" name="password" id="password"/>
+            <svg className="absolute top-2.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 256 256" fill={theme.colors.blueGray}><path d="M208,82H174V56a46,46,0,0,0-92,0V82H48A14,14,0,0,0,34,96V208a14,14,0,0,0,14,14H208a14,14,0,0,0,14-14V96A14,14,0,0,0,208,82ZM94,56a34,34,0,0,1,68,0V82H94ZM210,208a2,2,0,0,1-2,2H48a2,2,0,0,1-2-2V96a2,2,0,0,1,2-2H208a2,2,0,0,1,2,2Zm-82-94a26,26,0,0,0-6,51.29V184a6,6,0,0,0,12,0V165.29A26,26,0,0,0,128,114Zm0,40a14,14,0,1,1,14-14A14,14,0,0,1,128,154Z"/></svg>
+            <Input placeholder="Insira sua senha" type="password" name="password" id="password" />
           </div>
 
           <label className="block mt-6" htmlFor="password_confirm">Confirme a senha</label>
           <div className="relative">
-            <svg className="absolute top-2.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="#9caccb" viewBox="0 0 256 256"><path d="M208,82H174V56a46,46,0,0,0-92,0V82H48A14,14,0,0,0,34,96V208a14,14,0,0,0,14,14H208a14,14,0,0,0,14-14V96A14,14,0,0,0,208,82ZM94,56a34,34,0,0,1,68,0V82H94ZM210,208a2,2,0,0,1-2,2H48a2,2,0,0,1-2-2V96a2,2,0,0,1,2-2H208a2,2,0,0,1,2,2Zm-82-94a26,26,0,0,0-6,51.29V184a6,6,0,0,0,12,0V165.29A26,26,0,0,0,128,114Zm0,40a14,14,0,1,1,14-14A14,14,0,0,1,128,154Z"></path></svg>
-            <input className="block w-full h-12 pl-8 border-b-[2px] border-[#9caccb] placeholder:text-[#9caccb]" placeholder="Insira sua senha novamente" type="password" name="password_confirm" id="password_confirm"/>
+            <svg className="absolute top-2.5" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 256 256" fill={theme.colors.blueGray}><path d="M208,82H174V56a46,46,0,0,0-92,0V82H48A14,14,0,0,0,34,96V208a14,14,0,0,0,14,14H208a14,14,0,0,0,14-14V96A14,14,0,0,0,208,82ZM94,56a34,34,0,0,1,68,0V82H94ZM210,208a2,2,0,0,1-2,2H48a2,2,0,0,1-2-2V96a2,2,0,0,1,2-2H208a2,2,0,0,1,2,2Zm-82-94a26,26,0,0,0-6,51.29V184a6,6,0,0,0,12,0V165.29A26,26,0,0,0,128,114Zm0,40a14,14,0,1,1,14-14A14,14,0,0,1,128,154Z"/></svg>
+            <Input placeholder="Insira sua senha novamente" type="password" name="password_confirm" id="password_confirm" />
           </div>
-          <input className="block mx-auto p-4 mt-6 rounded-full w-1/2 text-white font-bold bg-[#9caccb] hover:bg-[#8895ac] cursor-pointer" type="submit" value="Sign Up"/>
+          <input
+            className="block mx-auto p-4 mt-6 rounded-full w-1/2 text-white font-bold cursor-pointer"
+            style={{ background: theme.colors.blueGray }}
+            type="submit"
+            value="Sign Up"
+          />
 
         </form>
 

--- a/frontend/components/SafeImage/index.tsx
+++ b/frontend/components/SafeImage/index.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import { Container } from "./styles";
 import Image, { StaticImageData } from "next/image";
 import { TranslatedSpan } from "../TranslatedSpan";
-import { useThemeContext } from "../Provider/Provider";
 
 export interface SafeImageProps {
   src: string | StaticImageData;
@@ -25,13 +24,12 @@ export interface SafeImageProps {
 
 export const SafeImage = ({ src, text, width = 40, height, className, alt, onClick }: SafeImageProps) => {
   const [imageError, setImageError] = useState(false);
-  const theme = useThemeContext();
   const finalHeight = height ?? width;
 
   return (
     <Container width={width} height={finalHeight}>
       {!imageError ? (
-        <div className={theme.isLight ? "invert" : "" + (className || "")}>
+        <div className={className ?? ""}>
           <Image
             unoptimized
             src={src}

--- a/frontend/components/SignButtons/index.jsx
+++ b/frontend/components/SignButtons/index.jsx
@@ -8,12 +8,13 @@ import defaultIcon from "@/assets/img/default_user_photo.png";
 import { useRouter } from 'next/navigation';
 import { SafeImage } from '../SafeImage';
 import { DropDown } from '../DropDown';
-import { theme } from '@/styles/theme';
+import { useTheme } from 'styled-components';
 
 
 export const SignButtons = () => {
   const { updateSessionId, updateToken, updateUser, userId, user } = useContext(PageContext);
   const router = useRouter();
+  const theme = useTheme();
 
 
   function handleSignOut() {
@@ -41,7 +42,16 @@ export const SignButtons = () => {
   if (!userId) {
     return (
       <Container>
-        <button type='button' onClick={handleSignIn} className='black_btn'>
+        <button
+          type='button'
+          onClick={handleSignIn}
+          style={{
+            background: theme.colors.blueGray,
+            color: theme.colors.white,
+            padding: '0.8rem 1.6rem',
+            borderRadius: theme.radius.default,
+          }}
+        >
           Sign in
         </button>
       </Container>

--- a/frontend/components/SignUpForm/styles.ts
+++ b/frontend/components/SignUpForm/styles.ts
@@ -65,7 +65,7 @@ export const StrengthWrapper = styled.div`
   width: 100%;
   min-width: 200px;
   height: 0.5rem;
-  background: #d1d5db;
+  background: ${({ theme }: { theme: DefaultTheme }) => theme.colors.lightGray};
   border-radius: ${({ theme }: { theme: DefaultTheme }) => theme.radius.small};
   margin-top: 0.25rem;
 `;
@@ -75,6 +75,10 @@ export const StrengthBar = styled.div<{ strength: number }>`
   width: ${({ strength }) => `${(strength / 5) * 100}%`};
   border-radius: inherit;
   transition: width 0.3s ease;
-  background-color: ${({ strength }) =>
-    strength <= 2 ? '#ef4444' : strength === 3 ? '#facc15' : '#22c55e'};
+  background-color: ${({ strength, theme }) =>
+    strength <= 2
+      ? theme.colors.dangerColor
+      : strength === 3
+        ? theme.colors.yellow
+        : theme.colors.successfulGreen};
 `;

--- a/frontend/styles/COLORS.ts
+++ b/frontend/styles/COLORS.ts
@@ -33,6 +33,8 @@ export enum Colors {
   orange = "#de4909",
   pacificBlue = "#0922de",
   lightBlue = "#4ca0e0",
+  blueGray = "#9caccb",
+  blueGrayDark = "#8895ac",
   successfulGreen = "#1bba06",
   dangerRed = "#d62e2e",
   darkerDangerRed = "#b75555",

--- a/frontend/styles/globalStyles.ts
+++ b/frontend/styles/globalStyles.ts
@@ -30,7 +30,6 @@ export const GlobalStyles = createGlobalStyle`
     ${({ theme }) => css`
       font-family: "Montserrat", sans-serif;
       font-size: 1.8rem !important;
-      background: #222;
       background: ${theme.colors.mainBg};
       color: ${theme.colors.secondaryColor}
       font-family: ${({ theme }) => theme.font.family.default};

--- a/frontend/styles/theme.ts
+++ b/frontend/styles/theme.ts
@@ -96,5 +96,18 @@ export const theme = {
 } as const;
 
 export const themeLight = {
-  ...theme
+  ...theme,
+  colors: {
+    ...theme.colors,
+    mainBg: Colors.white,
+    mainColor: Colors.black,
+    secondaryBg: Colors.lightGray,
+    secondaryBgDarker: Colors.darkGray,
+    secondaryColor: Colors.black,
+    borderColor: Colors.lightGrey,
+  },
+  gradient: {
+    ...theme.gradient,
+    darkGreyGradient: "rgba(255, 255, 255, 0.6)",
+  },
 } as const;


### PR DESCRIPTION
## Summary
- load persisted theme and apply light mode
- expose new light theme variant
- use theme colors in Register, SignUpForm and LoginForm
- remove hard-coded color from GlobalStyles

## Testing
- `npm run lint` *(fails: next not found)*
- `./mvnw -q test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6861911859b083289c492599ea42e4de