### PR TITLE
Fix main logo path

### DIFF
--- a/frontend/components/MainLogo/index.tsx
+++ b/frontend/components/MainLogo/index.tsx
@@ -8,7 +8,7 @@ export const MainLogo = (): ReactElement => {
     <Container>
       <ActiveLink href="/" target="_self">
         <SafeImage
-          src="/public/assets/img/pets_icon.png"
+          src="/assets/img/pets_icon.png"
           alt="Logo do site Adote um animalzinho"
           width={50}
           height={50}


### PR DESCRIPTION
## Summary
- use the proper path for pets_icon in MainLogo

## Testing
- `./mvnw -q test` *(fails: Failed to fetch Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_686194ba9d408328b0a989a776203ede