### PR TITLE
Fix lint issues for frontend deploy

### DIFF
--- a/frontend/app/editPet/[id]/page.tsx
+++ b/frontend/app/editPet/[id]/page.tsx
@@ -1,24 +1,24 @@
 "use client";
-import { useContext, useEffect, useState } from "react";
+import { use, useContext, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import type { PageProps } from "next";
 import { PageContext } from "@/context/PageContext";
 import { fetchTk } from "@/lib/helper";
 import EditPetForm from "@/components/EditPetForm/EditPetForm";
 import type { Pet } from "@/types/pet";
 
-export default function EditPetPage({ params }: PageProps<{ id: string }>) {
+export default function EditPetPage({ params }: { params: Promise<{ id: string }> }) {
   const { token } = useContext(PageContext);
   const [pet, setPet] = useState<Pet | null>(null);
   const router = useRouter();
+  const { id } = use(params);
 
   useEffect(() => {
     if (!token) return;
-    fetchTk(`/api/pets/${params.id}`, { headers: { Authorization: token } })
+    fetchTk(`/api/pets/${id}`, { headers: { Authorization: token } })
       .then((res) => res.json())
       .then((data) => setPet(data))
       .catch((err) => console.error("fetch pet", err));
-  }, [token, params.id]);
+  }, [token, id]);
 
   if (!pet) return <p>Carregando...</p>;
 

--- a/frontend/app/editPet/[id]/page.tsx
+++ b/frontend/app/editPet/[id]/page.tsx
@@ -1,22 +1,13 @@
 "use client";
 import { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import type { PageProps } from "next";
 import { PageContext } from "@/context/PageContext";
 import { fetchTk } from "@/lib/helper";
 import EditPetForm from "@/components/EditPetForm/EditPetForm";
+import type { Pet } from "@/types/pet";
 
-interface Pet {
-  id: string;
-  nome: string;
-  descricao?: string;
-  tipo?: string;
-  tags?: string[];
-  imagem?: string;
-  imagens?: string[];
-  localizacao?: Record<string, never>;
-}
-
-export default function EditPetPage({ params }: { params: { id: string } }) {
+export default function EditPetPage({ params }: PageProps<{ id: string }>) {
   const { token } = useContext(PageContext);
   const [pet, setPet] = useState<Pet | null>(null);
   const router = useRouter();

--- a/frontend/app/pet/[id]/page.tsx
+++ b/frontend/app/pet/[id]/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { use, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Section } from "@/components/Section";
 import { LoadingSection } from "@/components/LoadingSection";
@@ -8,32 +8,21 @@ import { Carousel } from "@/components/Carousel";
 import { TagChip } from "@/components/TagChip";
 import { fetchTk } from "@/lib/helper";
 import * as Styled from "./styles";
+import { Pet } from "@/types/pet";
 
-type Pet = {
-  id: string;
-  nome: string;
-  descricao?: string;
-  tipo?: string;
-  tags?: string[];
-  imagem?: string;
-  imagens?: string[];
-  localizacao?: Record<string, never>;
-  email?: string;
-  telefone?: string;
-};
-
-export default function PetPage({ params }: { params: { id: string } }) {
+export default function PetPageClient({ params }: { params: Promise<{ id: string }> }) {
   const [pet, setPet] = useState<Pet | null>(null);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
+  const { id } = use(params);
 
   useEffect(() => {
-    fetchTk(`/api/pets/${params.id}`)
+    fetchTk(`/api/pets/${id}`)
       .then((res) => res.json())
       .then((data) => setPet(data))
       .catch((err) => console.error("fetch pet", err))
       .finally(() => setLoading(false));
-  }, [params.id]);
+  }, [id]);
 
   if (loading) return <LoadingSection />;
   if (!pet) return <Section>Pet não encontrado</Section>;

--- a/frontend/components/EditPetForm/EditPetForm.tsx
+++ b/frontend/components/EditPetForm/EditPetForm.tsx
@@ -1,8 +1,9 @@
 "use client";
 import PetForm from "../PetFormParts/PetForm";
+import { Pet } from "../../types/pet";
 
 export interface EditPetFormProps {
-  pet: any;
+  pet: Pet;
   token: string;
   onSuccess?: () => void;
 }

--- a/frontend/components/LocationSearchInput/styles.ts
+++ b/frontend/components/LocationSearchInput/styles.ts
@@ -1,7 +1,7 @@
 import styled, { DefaultTheme, css } from 'styled-components';
 
 export const Wrapper = styled.div`
-  ${({ theme }: { theme: DefaultTheme }) => css`
+  ${() => css`
     position: relative;
     width: 100%;
   `}

--- a/frontend/components/PetFormParts/ImageInput.tsx
+++ b/frontend/components/PetFormParts/ImageInput.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { ChangeEvent } from "react";
+import Image from "next/image";
 
 export interface ImageInputProps {
   previews: string[];
@@ -13,7 +14,14 @@ export default function ImageInput({ previews, onChange }: ImageInputProps) {
       {previews.length > 0 && (
         <div className="image-wrapper">
           {previews.map((src, i) => (
-            <img key={i} src={src} alt="Pré-visualização" className="preview" />
+            <Image
+              key={i}
+              src={src}
+              alt="Pré-visualização"
+              className="preview"
+              width={100}
+              height={100}
+            />
           ))}
         </div>
       )}

--- a/frontend/components/PetFormParts/PetForm.tsx
+++ b/frontend/components/PetFormParts/PetForm.tsx
@@ -206,7 +206,7 @@ export default function PetForm({
     setLoading(true);
     setError(null);
     await updateCoordinates();
-    let imageUrls: string[] = imageUrl ? [imageUrl] : [];
+    const imageUrls: string[] = imageUrl ? [imageUrl] : [];
     if (form.imagens.length > 0) {
       if (!auth.currentUser) {
         try {

--- a/frontend/components/Register/index.tsx
+++ b/frontend/components/Register/index.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import google from "../../assets/google.svg";
 import { SafeImage } from "../SafeImage";
 import styled, { useTheme } from "styled-components";

--- a/frontend/components/SignUpForm/index.tsx
+++ b/frontend/components/SignUpForm/index.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { PageContext } from "@/context/PageContext";
 import { getUserByFirebaseUserId } from "@/lib/helper";
 import { LoadingSpin } from "@/components/LoadingSpin";
-import { signInWithGoogle, auth, getRedirectedUser } from "@/lib/firebase";
+import { signInWithGoogle, getRedirectedUser } from "@/lib/firebase";
 import googleImage from "@/public/assets/google.svg";
 import Image from "next/image";
 import Link from "next/link";

--- a/frontend/components/SignUpForm/index.tsx
+++ b/frontend/components/SignUpForm/index.tsx
@@ -6,7 +6,6 @@ import { PageContext } from "@/context/PageContext";
 import { getUserByFirebaseUserId } from "@/lib/helper";
 import { LoadingSpin } from "@/components/LoadingSpin";
 import { signInWithGoogle, auth, getRedirectedUser } from "@/lib/firebase";
-import { useAuthState } from "react-firebase-hooks/auth";
 import googleImage from "@/public/assets/google.svg";
 import Image from "next/image";
 import Link from "next/link";
@@ -18,7 +17,6 @@ export const SignUpForm = () => {
   const [loading, setLoading] = useState(false);
   const [strength, setStrength] = useState(0);
   const { updateSessionId, handleLogin, updateToken, updateUser } = useContext(PageContext);
-  const [user] = useAuthState(auth);
   const router = useRouter();
 
   useEffect(() => {

--- a/frontend/types/pet.ts
+++ b/frontend/types/pet.ts
@@ -1,0 +1,26 @@
+export interface Location {
+  pais?: string;
+  estado?: string;
+  cidade?: string;
+  bairro?: string;
+  rua?: string;
+  numero?: string;
+  cep?: string;
+  latitude?: number;
+  longitude?: number;
+}
+
+export interface Pet {
+  id: string;
+  nome: string;
+  descricao?: string;
+  tipo?: string;
+  tags?: string[];
+  imagem?: string;
+  imagens?: string[];
+  email?: string;
+  telefone?: string;
+  localizacao?: Location;
+  matchTags?: string[];
+  missingTags?: string[];
+}


### PR DESCRIPTION
## Summary
- define shared `Pet` and `Location` interfaces
- type `EditPetForm` props
- remove unused `theme` param in `LocationSearchInput`
- use `next/image` in `ImageInput`
- declare `imageUrls` as const
- drop unused imports/variables in Register and SignUp forms

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org)*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68619af44a7c83288097f7f0dee95103