### PR TITLE
Fix dropdown style type

### DIFF
--- a/frontend/components/DropDown/DropDown.tsx
+++ b/frontend/components/DropDown/DropDown.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
+import { ReactElement, CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
 import { Container } from './styles';
 import { IconSpan } from '../IconSpan';
 import { DropDownProps, Styling } from './types';
@@ -46,7 +46,10 @@ export const DropDown = ({ children, dropDownId, toggleId, items, height, style 
   }, [isOpen, style, theme.colors.mainBg, theme.colors.shadowColor]);
 
   return (
-    <Container height={height} ref={containerRef} style={style}
+    <Container
+      height={height}
+      ref={containerRef}
+      style={style as CSSProperties}
       onClick={toggle}
     >
       <button


### PR DESCRIPTION
## Summary
- use `CSSProperties` for the dropdown style prop
- cast style prop before passing to the styled container

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6861b03d92f483289e8074950bb7737f