### PR TITLE
Add Swagger documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ firebase init
 firebase deploy
 
 ```
+A documentacao Swagger pode ser acessada em http://localhost:8080/swagger-ui/index.html
+
 
 ### ⚙️ Configurar Firebase
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -53,11 +53,17 @@
 			<version>9.2.0</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-crypto</artifactId>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-crypto</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.3.0</version>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/backend/src/main/java/com/example/backend/OpenApiConfig.java
+++ b/backend/src/main/java/com/example/backend/OpenApiConfig.java
@@ -1,0 +1,19 @@
+package com.example.backend;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI apiInfo() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Backend API")
+                        .version("1.0.0"));
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=backend
+
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
## Summary
- enable Swagger UI with springdoc
- expose `/swagger-ui.html` path
- document path in README

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven due to no network)*

------
https://chatgpt.com/codex/tasks/task_b_6861b7f5f6848328b1e4af4a9ecf24c2